### PR TITLE
[DMESH-1835] Adjusting Condition to support wildcard namespaces

### DIFF
--- a/modules/iam-role-for-serviceaccount/main.tf
+++ b/modules/iam-role-for-serviceaccount/main.tf
@@ -1,5 +1,6 @@
 locals {
   oidc_fully_qualified_subjects = format("system:serviceaccount:%s:%s", var.namespace, var.serviceaccount)
+  match_string = var.wildcard_namespace ? "StringLike" : "StringEquals"
 }
 
 # security/policy
@@ -16,7 +17,7 @@ resource "aws_iam_role" "irsa" {
         Federated = var.oidc_arn
       }
       Condition = {
-        StringLike = {
+        "${local.match_string}" = {
           format("%s:sub", var.oidc_url) = local.oidc_fully_qualified_subjects
         }
       }

--- a/modules/iam-role-for-serviceaccount/main.tf
+++ b/modules/iam-role-for-serviceaccount/main.tf
@@ -1,6 +1,5 @@
 locals {
   oidc_fully_qualified_subjects = format("system:serviceaccount:%s:%s", var.namespace, var.serviceaccount)
-  match_string = var.wildcard_namespace ? "StringLike" : "StringEquals"
 }
 
 # security/policy
@@ -17,7 +16,7 @@ resource "aws_iam_role" "irsa" {
         Federated = var.oidc_arn
       }
       Condition = {
-        "${local.match_string}" = {
+        "${var.iam_conditional_operator}" = {
           format("%s:sub", var.oidc_url) = local.oidc_fully_qualified_subjects
         }
       }

--- a/modules/iam-role-for-serviceaccount/main.tf
+++ b/modules/iam-role-for-serviceaccount/main.tf
@@ -16,7 +16,7 @@ resource "aws_iam_role" "irsa" {
         Federated = var.oidc_arn
       }
       Condition = {
-        StringEquals = {
+        StringLike = {
           format("%s:sub", var.oidc_url) = local.oidc_fully_qualified_subjects
         }
       }

--- a/modules/iam-role-for-serviceaccount/variables.tf
+++ b/modules/iam-role-for-serviceaccount/variables.tf
@@ -44,3 +44,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "wildcard_namespace" {
+  description = "Conditional inticator for Wildcard Namespace support"
+  type = bool
+  default = false
+}

--- a/modules/iam-role-for-serviceaccount/variables.tf
+++ b/modules/iam-role-for-serviceaccount/variables.tf
@@ -45,8 +45,8 @@ variable "tags" {
   default     = {}
 }
 
-variable "wildcard_namespace" {
+variable "iam_conditional_operator" {
   description = "Conditional inticator for Wildcard Namespace support"
-  type = bool
-  default = false
+  type = map(string)
+  default = "StringEquals"
 }

--- a/modules/iam-role-for-serviceaccount/variables.tf
+++ b/modules/iam-role-for-serviceaccount/variables.tf
@@ -46,7 +46,7 @@ variable "tags" {
 }
 
 variable "iam_conditional_operator" {
-  description = "Conditional inticator for Wildcard Namespace support"
+  description = "Conditional indicator for Wildcard Namespace support"
   type = string
   default = "StringEquals"
 }

--- a/modules/iam-role-for-serviceaccount/variables.tf
+++ b/modules/iam-role-for-serviceaccount/variables.tf
@@ -47,6 +47,6 @@ variable "tags" {
 
 variable "iam_conditional_operator" {
   description = "Conditional inticator for Wildcard Namespace support"
-  type = map(string)
+  type = string
   default = "StringEquals"
 }


### PR DESCRIPTION
OIDC module needs to support StringLike conditions when mapping to EKS wildcard namespaces .

Per https://datarobot.atlassian.net/browse/DMESH-1833 and https://github.com/datarobot/cloud_ops/pull/565