### PR TITLE
[DMESH-1835] remove deprecated syntax

### DIFF
--- a/modules/iam-role-for-serviceaccount/main.tf
+++ b/modules/iam-role-for-serviceaccount/main.tf
@@ -16,7 +16,7 @@ resource "aws_iam_role" "irsa" {
         Federated = var.oidc_arn
       }
       Condition = {
-        "${var.iam_conditional_operator}" = {
+        var.iam_conditional_operator = {
           format("%s:sub", var.oidc_url) = local.oidc_fully_qualified_subjects
         }
       }

--- a/modules/iam-role-for-serviceaccount/main.tf
+++ b/modules/iam-role-for-serviceaccount/main.tf
@@ -16,7 +16,7 @@ resource "aws_iam_role" "irsa" {
         Federated = var.oidc_arn
       }
       Condition = {
-        var.iam_conditional_operator = {
+        (var.iam_conditional_operator) = {
           format("%s:sub", var.oidc_url) = local.oidc_fully_qualified_subjects
         }
       }


### PR DESCRIPTION
According to terraform plan:

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.